### PR TITLE
Protect mutation routes with requireAuth and ownership checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,43 @@
+name: CI/CD
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14.1
+        env:
+          POSTGRES_USER: opencarts_app
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: oc-test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      NODE_ENV: test
+      DB_USERNAME: opencarts_app
+      DB_PASSWORD: password
+      DB_HOST: localhost
+      DB_TESTURI: postgres://opencarts_app:password@localhost/oc-test
+      DB_TESTDB: oc-test
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      JWT_EXPIRES_IN: ${{ secrets.JWT_EXPIRES_IN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm install
+      - name: Run backend tests
+        run: cd backend && npm run test
+      - name: Run frontend coverage
+        run: npm run coverage

--- a/backend/__tests__/reviews.test.js
+++ b/backend/__tests__/reviews.test.js
@@ -6,37 +6,42 @@ const supertest = require('supertest');
 const testReview = {
   review: 'the food was ok!',
   rating: 3,
-  userId: 1,
   cartId: 3,
   reservationId: 2,
 }
 
 const getCsrfToken = async (agent) => {
   const xsrfRes = await agent
-    .get('/api/csrf/restore')  
+    .get('/api/csrf/restore')
   let cookie = xsrfRes.headers['set-cookie'][1].split(';')[0]
-  cookie = cookie.split('=')[1]    
+  cookie = cookie.split('=')[1]
   return cookie
-}   
+}
 
 describe('test the review post route', () => {
   let testDb = db;
-  
+
   const agent = supertest.agent(app);
 
   it('should respond with status 200 and the review in json format', async () => {
     const cookie = await getCsrfToken(agent);
+
+    await agent
+      .post('/api/session')
+      .set('XSRF-TOKEN', cookie)
+      .send({ credential: 'demo', password: 'password' });
+
     const {
-      review, rating, userId, cartId, reservationId
+      review, rating, cartId, reservationId
     } = testReview
     const response = await agent
       .post('/api/reviews')
       .set('XSRF-TOKEN', cookie)
       .send({
-        review, rating, userId, cartId, reservationId
-      })      
-      .set('Accept', 'application/json')       
-      
+        review, rating, cartId, reservationId
+      })
+      .set('Accept', 'application/json')
+
     expect(response.headers['content-type']).toMatch(/json/)
     expect(response.status).toEqual(200);
     expect(response.body.review).toEqual(testReview.review)

--- a/backend/__tests__/user.test.js
+++ b/backend/__tests__/user.test.js
@@ -3,14 +3,31 @@ const db = require('../db/models');
 
 const supertest = require('supertest');
 
+const getCsrfToken = async (agent) => {
+  const xsrfRes = await agent.get('/api/csrf/restore');
+  let cookie = xsrfRes.headers['set-cookie'][1].split(';')[0];
+  cookie = cookie.split('=')[1];
+  return cookie;
+};
+
 describe('test the get user reservations route', () => {
   let testDb = db;
-  
-  it("should respond with 200 and a json payload", async () => {
-    const response = await supertest(app)
-    .get('/api/users/1/reservations')
-    .set('Accept', 'application/json')    
+
+  const agent = supertest.agent(app);
+
+  it('should respond with 200 and a json payload', async () => {
+    const cookie = await getCsrfToken(agent);
+
+    await agent
+      .post('/api/session')
+      .set('XSRF-TOKEN', cookie)
+      .send({ credential: 'demo', password: 'password' });
+
+    const response = await agent
+      .get('/api/users/1/reservations')
+      .set('Accept', 'application/json');
+
     expect(response.headers['content-type']).toMatch(/json/);
     expect(response.status).toEqual(200);
-  })
-})
+  });
+});

--- a/backend/routes/api/reservations.js
+++ b/backend/routes/api/reservations.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const asyncHandler = require('express-async-handler');
 const { Op } = require('sequelize');
+const { requireAuth } = require('../../utils/auth');
 
 const router = express.Router();
 const { Reservation, Cart } = require('../../db/models');
@@ -61,19 +62,14 @@ router.post(
 // make a new reservation
 router.post(
   '/new',
+  requireAuth,
   asyncHandler(async (req, res) => {
-    const {
-      dateTime,
-      partySize,
-      userId,
-      cartId,
-    } = req.body;
-
+    const { dateTime, partySize, cartId } = req.body;
     const newRes = await Reservation.create({
       dateTime,
       partySize,
-      userId,
       cartId,
+      userId: req.user.id,
     });
     res.json(newRes);
   }),
@@ -81,36 +77,40 @@ router.post(
 
 router.patch(
   '/:id(\\d+)',
+  requireAuth,
   asyncHandler(async (req, res) => {
     const id = parseInt(req.params.id, 10);
-    const {
-      dateTime,
-      partySize,
-      userId,
-    } = req.body;
+    const { dateTime, partySize } = req.body;
     const reservation = await Reservation.findByPk(id);
+    if (!reservation || reservation.userId !== req.user.id) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
     reservation.dateTime = dateTime;
     reservation.partySize = partySize;
     await reservation.save();
     const reservations = await Reservation.findAll({
       where: {
-        userId,
+        userId: req.user.id,
         dateTime: {
           [Op.gte]: Date.now(),
         },
       },
       include: [Cart],
     });
-    res.json(reservations);
+    return res.json(reservations);
   }),
 );
 router.delete(
   '/:id(\\d+)',
+  requireAuth,
   asyncHandler(async (req, res) => {
     const reservationId = parseInt(req.params.id, 10);
     const reservation = await Reservation.findByPk(reservationId);
+    if (!reservation || reservation.userId !== req.user.id) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
     await reservation.destroy();
-    res.json({ message: 'Reservation Deleted', id: reservationId });
+    return res.json({ message: 'Reservation Deleted', id: reservationId });
   }),
 );
 

--- a/backend/routes/api/reviews.js
+++ b/backend/routes/api/reviews.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const asyncHandler = require('express-async-handler');
+const { requireAuth } = require('../../utils/auth');
 const { Review, Reservation } = require('../../db/models');
 
 const router = express.Router();
@@ -19,19 +20,22 @@ router.get(
 );
 
 // Create a new review
-// req.body fields: review, rating, userId, cartId, reservationId
 router.post(
   '/',
-  asyncHandler(async (req, res) => {    
-    const { reservationId } = req.body;
-    const data = req.body;
-    const review = await Review.create(data)
-    const reservation = await Reservation.findOne({ where: {id: reservationId}});
-
-    await reservation.update({ reviewed: true })
-
-    res.json(review)
-  })
+  requireAuth,
+  asyncHandler(async (req, res) => {
+    const { review, rating, cartId, reservationId } = req.body;
+    const newReview = await Review.create({
+      review,
+      rating,
+      cartId,
+      reservationId,
+      userId: req.user.id,
+    });
+    const reservation = await Reservation.findOne({ where: { id: reservationId } });
+    await reservation.update({ reviewed: true });
+    res.json(newReview);
+  }),
 )
 
 module.exports = router;

--- a/backend/routes/api/users.js
+++ b/backend/routes/api/users.js
@@ -3,7 +3,7 @@ const asyncHandler = require('express-async-handler');
 const { Op } = require('sequelize');
 const { check } = require('express-validator');
 const { handleValidationErrors } = require('../../utils/validation');
-const { setTokenCookie } = require('../../utils/auth');
+const { setTokenCookie, requireAuth } = require('../../utils/auth');
 const { User, Reservation, Cart } = require('../../db/models');
 
 const router = express.Router();
@@ -47,8 +47,9 @@ router.post(
 // get a user's reservations
 router.get(
   '/:id(\\d+)/reservations',
+  requireAuth,
   asyncHandler(async (req, res) => {
-    const userId = parseInt(req.params.id, 10);
+    const userId = req.user.id;
     const futureReservations = await Reservation.findAll({
       where: {
         userId,


### PR DESCRIPTION
## Summary

- Added `requireAuth` to `POST /reservations/new`, `PATCH /reservations/:id`, `DELETE /reservations/:id`, `POST /reviews`, and `GET /users/:id/reservations` — unauthenticated requests now receive a 401
- Added ownership checks to `PATCH` and `DELETE /reservations/:id` — a user can only modify or cancel their own reservations (403 otherwise)
- `userId` on all protected routes is now derived from `req.user.id` (the verified JWT) instead of being accepted from the request body — as a side effect this also fixes the mass assignment vulnerability on `POST /reviews`
- No frontend changes required; the extra `userId` sent in request bodies is silently ignored by the updated handlers
- Replaced CircleCI config with a GitHub Actions workflow (`.github/workflows/ci-cd.yml`) that runs backend tests and frontend coverage on every push and PR, using Node 20 LTS and a Postgres 14 service container

## Test plan

- [ ] Log in and create, edit, and cancel a reservation — confirm all succeed
- [ ] Log out and attempt `POST /api/reservations/new` directly — confirm 401
- [ ] Log in as user A, attempt to `PATCH`/`DELETE` a reservation belonging to user B — confirm 403
- [ ] Submit a review on a past reservation — confirm it saves with the correct `userId`
- [ ] Attempt `POST /api/reviews` while logged out — confirm 401
- [ ] Confirm GitHub Actions CI runs and passes on this PR

🤖 Generated with [Claude Code](https://claude.ai/claude-code)