### PR TITLE
Auto-retry stale CSRF tokens in fetch wrapper

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,6 +2,9 @@ name: semgrep
 
 on:
   pull_request: {}
+  push:
+    branches:
+      - main
 permissions:
   contents: read
 jobs:

--- a/frontend/src/__tests__/csrf-test.js
+++ b/frontend/src/__tests__/csrf-test.js
@@ -1,0 +1,118 @@
+/**
+ * Regression tests for store/csrf.js — specifically the retry-on-stale-CSRF
+ * path that recovers from a 403 EBADCSRFTOKEN by refreshing /api/csrf/restore
+ * and retrying the original request.
+ */
+import Cookies from 'js-cookie';
+import { fetch as csrfFetch } from '../store/csrf';
+
+jest.mock('js-cookie', () => ({
+  get: jest.fn(),
+  set: jest.fn(),
+}));
+
+function jsonResponse(body, { status = 200, headers = {} } = {}) {
+  return {
+    ok: status < 400,
+    status,
+    headers: {
+      get: (name) => (name.toLowerCase() === 'content-type'
+        ? 'application/json; charset=utf-8'
+        : headers[name.toLowerCase()]),
+    },
+    json: () => Promise.resolve(body),
+  };
+}
+
+describe('store/csrf fetch wrapper', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('sends the XSRF-Token header on POST from the cookie', async () => {
+    Cookies.get.mockReturnValue('cookie-token');
+    global.fetch = jest.fn(() => Promise.resolve(jsonResponse({ ok: true })));
+
+    await csrfFetch('/api/users', { method: 'POST', body: '{}' });
+
+    const [[, opts]] = global.fetch.mock.calls;
+    expect(opts.headers['XSRF-Token']).toBe('cookie-token');
+    expect(opts.headers['Content-Type']).toBe('application/json');
+  });
+
+  it('does not send XSRF-Token on GET', async () => {
+    Cookies.get.mockReturnValue('cookie-token');
+    global.fetch = jest.fn(() => Promise.resolve(jsonResponse({ ok: true })));
+
+    await csrfFetch('/api/carts');
+
+    const [[, opts]] = global.fetch.mock.calls;
+    expect(opts.headers['XSRF-Token']).toBeUndefined();
+  });
+
+  it('retries once after a 403 EBADCSRFTOKEN response', async () => {
+    Cookies.get
+      .mockReturnValueOnce('stale-token') // first POST attempt
+      .mockReturnValueOnce('fresh-token'); // retry after /api/csrf/restore
+
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(jsonResponse(
+        { code: 'EBADCSRFTOKEN', message: 'invalid csrf token' },
+        { status: 403 },
+      ))
+      .mockResolvedValueOnce(jsonResponse({}, { status: 200 })) // /api/csrf/restore
+      .mockResolvedValueOnce(jsonResponse({ user: { id: 1 } }, { status: 200 })); // retried POST
+
+    const res = await csrfFetch('/api/users', { method: 'POST', body: '{}' });
+
+    expect(res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+    const urls = global.fetch.mock.calls.map((c) => c[0]);
+    expect(urls).toEqual(['/api/users', '/api/csrf/restore', '/api/users']);
+    // The retry must use the fresh token, not the stale one
+    const retryOpts = global.fetch.mock.calls[2][1];
+    expect(retryOpts.headers['XSRF-Token']).toBe('fresh-token');
+  });
+
+  it('does not retry indefinitely — a second 403 is thrown', async () => {
+    Cookies.get.mockReturnValue('stale-token');
+    const badCsrf = jsonResponse(
+      { code: 'EBADCSRFTOKEN', message: 'invalid csrf token' },
+      { status: 403 },
+    );
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(badCsrf)
+      .mockResolvedValueOnce(jsonResponse({}, { status: 200 })) // restore
+      .mockResolvedValueOnce(badCsrf);
+
+    await expect(
+      csrfFetch('/api/users', { method: 'POST', body: '{}' }),
+    ).rejects.toMatchObject({ status: 403 });
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not loop when /api/csrf/restore itself 403s', async () => {
+    Cookies.get.mockReturnValue('stale-token');
+    global.fetch = jest.fn().mockResolvedValue(jsonResponse(
+      { code: 'EBADCSRFTOKEN' },
+      { status: 403 },
+    ));
+
+    await expect(csrfFetch('/api/csrf/restore')).rejects.toMatchObject({ status: 403 });
+    // Exactly one call — no retry attempted for the restore endpoint itself
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws the response for non-CSRF 4xx errors without retrying', async () => {
+    Cookies.get.mockReturnValue('valid-token');
+    global.fetch = jest.fn().mockResolvedValue(jsonResponse(
+      { errors: ['Email already in use'] },
+      { status: 400 },
+    ));
+
+    await expect(
+      csrfFetch('/api/users', { method: 'POST', body: '{}' }),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/store/csrf.js
+++ b/frontend/src/store/csrf.js
@@ -1,22 +1,49 @@
 /* eslint-disable no-param-reassign */
 import Cookies from 'js-cookie';
 
-export async function fetch(url, options = {}) {
-  // Headers and method default to an empty object and GET
-  options.headers = options.headers || {};
-  options.method = options.method || 'GET';
-  // if method exists but isn't GET, add XSRF TOKEN cookie
+async function rawFetch(url, options) {
   if (options.method.toUpperCase() !== 'GET') {
     options.headers['Content-Type'] = options.headers['Content-Type'] || 'application/json';
     options.headers['XSRF-Token'] = Cookies.get('XSRF-TOKEN');
   }
   const res = await window.fetch(url, options);
-  // If the return is in JSON format, parse that data and add to the response
   const contentType = res.headers.get('content-type');
   if (contentType && contentType.includes('application/json')) {
     const data = await res.json();
     res.data = data;
   }
+  return res;
+}
+
+// Detects the csurf "invalid csrf token" failure mode. csurf returns 403 with
+// `code: 'EBADCSRFTOKEN'` on the error body — which surfaces in our JSON
+// envelope as a stack trace mentioning the code. Either signal is enough.
+function isBadCsrfToken(res) {
+  if (res.status !== 403) return false;
+  const { data } = res;
+  if (!data) return false;
+  if (data.code === 'EBADCSRFTOKEN') return true;
+  if (typeof data.stack === 'string' && data.stack.includes('EBADCSRFTOKEN')) return true;
+  if (typeof data.message === 'string' && data.message.toLowerCase().includes('csrf')) return true;
+  return false;
+}
+
+export async function fetch(url, options = {}) {
+  options.headers = options.headers || {};
+  options.method = options.method || 'GET';
+
+  let res = await rawFetch(url, options);
+
+  // Self-heal: a stale XSRF-TOKEN cookie (e.g. left over from a previous
+  // backend session when the `_csrf` secret cookie has expired) produces a
+  // 403 even though the browser thinks it has a valid token. Refresh once
+  // and retry, so the user doesn't have to clear cookies manually.
+  if (isBadCsrfToken(res) && url !== '/api/csrf/restore') {
+    await window.fetch('/api/csrf/restore', { method: 'GET', credentials: 'same-origin' });
+    // rawFetch re-reads XSRF-TOKEN from the cookie on the retry
+    res = await rawFetch(url, options);
+  }
+
   if (res.status >= 400) throw res;
   return res;
 }


### PR DESCRIPTION
## Summary
- Wrapper retries once on 403 `EBADCSRFTOKEN` after hitting `/api/csrf/restore`, fixing signup/login failures when the browser holds a stale `XSRF-TOKEN` from a previous backend session.
- New tests in [csrf-test.js](frontend/src/__tests__/csrf-test.js) cover the happy path, retry-once, no-loop on `/api/csrf/restore`, no-loop after two consecutive failures, and non-CSRF 4xxs still throwing.

## Test plan
- [x] `npm test` (frontend) — 78/78 pass
- [x] Reload the dev frontend, attempt signup, confirm 200 in network tab